### PR TITLE
Spike/trey standardize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @fulcrumapp/chaos-monkeys

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM public.ecr.aws/docker/library/python:3.9-slim-bookworm
+
+# Install dependencies
+RUN apt-get update && apt-get install -y curl gnupg && \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g swagger-cli@4.0.4 && \
+    curl -L https://github.com/mikefarah/yq/releases/download/v4.18.1/yq_linux_amd64 -o /usr/local/bin/yq && \
+    chmod +x /usr/local/bin/yq && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy scripts
+COPY convert_openapi.sh .
+COPY swagger_cleaner.py .
+
+# Make convert_openapi.sh executable
+RUN chmod +x convert_openapi.sh
+
+# Set the entrypoint
+ENTRYPOINT ["./convert_openapi.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install pyyaml
 
 # Copy package.json and install Node.js project dependencies into /app/node_modules
 COPY package.json ./
-# COPY package-lock.json* ./ # Optional: good practice to copy if it exists
+COPY package-lock.json* ./ # Good practice to copy if it exists
 RUN npm install # This creates /app/node_modules in the image layer
 
 # Declare /app/node_modules as a volume.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,33 @@
 FROM public.ecr.aws/docker/library/python:3.9-slim-bookworm
 
-# Install dependencies
+# Prevent Python from writing .pyc files
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Install system dependencies (curl, gnupg, Node.js)
 RUN apt-get update && apt-get install -y curl gnupg && \
-    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
-    npm install -g swagger-cli@4.0.4 && \
-    curl -L https://github.com/mikefarah/yq/releases/download/v4.18.1/yq_linux_amd64 -o /usr/local/bin/yq && \
-    chmod +x /usr/local/bin/yq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Set working directory
 WORKDIR /app
 
-# Copy scripts
+# Install Python project dependencies (globally in the image)
+RUN pip install pyyaml
+
+# Copy package.json and install Node.js project dependencies into /app/node_modules
+COPY package.json ./
+# COPY package-lock.json* ./ # Optional: good practice to copy if it exists
+RUN npm install # This creates /app/node_modules in the image layer
+
+# Declare /app/node_modules as a volume.
+# This ensures that the node_modules from the image are used and are not
+# created on the host, even if the script re-runs npm install.
+# Writes will go to an anonymous volume managed by Docker.
+VOLUME /app/node_modules
+
+# Copy application scripts
 COPY convert_openapi.sh .
 COPY swagger_cleaner.py .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,7 @@ WORKDIR /app
 # Install Python project dependencies (globally in the image)
 RUN pip install pyyaml
 
-# Copy package.json and install Node.js project dependencies into /app/node_modules
-COPY package.json ./
-# COPY package-lock.json* ./ # Optional: good practice to copy if it exists
-RUN npm install # This creates /app/node_modules in the image layer
-
+RUN npm install @apiture/openapi-down-convert api-spec-converter
 # Declare /app/node_modules as a volume.
 # This ensures that the node_modules from the image are used and are not
 # created on the host, even if the script re-runs npm install.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ This tool facilitates the conversion of OpenAPI 3.0 specifications to the Swagge
 
 ## Usage Instructions
 
+**Option 1: Using Docker (Recommended)**
+
+1.  **Build the Docker image:**
+    ```bash
+    docker build -t openapi-powerautomate-compat .
+    ```
+
+2.  **Run the Docker container:**
+    Place your OpenAPI 3.1 specification file (e.g., `my-api.json`) in the current directory.
+    ```bash
+    docker run -v "$(pwd):/app" openapi-powerautomate-compat my-api.json
+    ```
+    Replace `my-api.json` with the actual name of your OpenAPI file.
+
+**Option 2: Local Execution**
+
 - Clone this repository to your local machine.
 
 - Add your OpenAPI 3.1 specification to the repository root and name the file:

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ This tool facilitates the conversion of OpenAPI 3.0 specifications to the Swagge
     ```
 
 2.  **Run the Docker container:**
-    Place your OpenAPI 3.1 specification file (e.g., `my-api.json`) in the current directory.
+    Place your OpenAPI 3.1 specification file (e.g., `api-3.1.json`) in the current directory.
     ```bash
     docker run -v "$(pwd):/app" openapi-powerautomate-compat my-api.json
     ```
-    Replace `my-api.json` with the actual name of your OpenAPI file.
+    Rename your file to `api-3.1.json`.
 
 **Option 2: Local Execution**
 

--- a/convert_openapi.sh
+++ b/convert_openapi.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-# Initialize project
-npm init -y -q
-
-# Install Node.js dependencies
-npm install @apiture/openapi-down-convert api-spec-converter
-
 # Check OpenAPI 3.1 file
 if [[ ! -f "api-3.1.json" ]]; then
     echo "Error: api-3.1.json not found!"
@@ -26,15 +20,8 @@ if ! npx api-spec-converter --from=openapi_3 --to=swagger_2 --syntax=yaml api-3.
     exit 1
 fi
 
-# Set up Python virtual environment
-if [[ ! -d "venv" ]]; then
-    python3 -m venv venv
-fi
-source venv/bin/activate
-
-pip install pyyaml
-
 # Run swagger_cleaner.py
+# pyyaml is installed globally in the Docker image
 if ! python swagger_cleaner.py swagger-2.0.yaml; then
     echo "Error: swagger_cleaner.py execution failed!"
     exit 1


### PR DESCRIPTION
This pull request introduces a Dockerized workflow for converting OpenAPI 3.1 specifications to Swagger 2.0, replacing the previous local setup. Key changes include the addition of a `Dockerfile`, updates to the `README.md` to document Docker usage, and simplifications to the `convert_openapi.sh` script by removing redundant setup steps.

### Dockerization:
* Added a `Dockerfile` to create a lightweight Python-based Docker image with Node.js and Python dependencies pre-installed. The `convert_openapi.sh` script is set as the entrypoint.
* Declared `/app/node_modules` as a Docker volume to ensure consistency in dependency usage across environments.

### Documentation Updates:
* Updated `README.md` with instructions for using the new Dockerized workflow, including building and running the Docker container. Local execution instructions remain as an alternative option.

### Script Simplification:
* Removed Node.js dependency installation from `convert_openapi.sh`, as these are now handled in the Docker image.
* Removed Python virtual environment setup and local `pyyaml` installation from `convert_openapi.sh`, as `pyyaml` is now globally installed in the Docker image.