### PR TITLE
Taslk/flcrm 19626 add packaging task to conversion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The validation script (`./scripts/validate.sh`) checks:
 - ✓ Swagger 2.0 specification passes validation
 - ✓ No OpenAPI Generator warnings (warnings treated as errors)
 - ✓ Power Automate compatibility requirements
+- ✓ Microsoft certification package is complete and valid
 
 All generated artifacts are written to `build/` by default (configurable via the `WORK_DIR` environment variable).
 
@@ -153,8 +154,42 @@ All files are generated in `build/`:
 - `api-3.0.json` - Downgraded to OpenAPI 3.0
 - `swagger-2.0.yaml` - Converted to Swagger 2.0
 - `fulcrum-power-automate-connector.yaml` - **Final output** ready for Power Automate import
+- **`certified-connectors/Fulcrum/`** - Microsoft certification package:
+  - `apiDefinition.swagger.json` - Connector definition in JSON format
+  - `apiProperties.json` - Connection parameters and branding
+  - `README.md` - Connector documentation
 
 All generated files are gitignored and can be safely deleted after import.
+
+## Certification Package
+
+The tool automatically generates a complete Microsoft Power Platform certification package ready for submission to the [PowerPlatformConnectors repository](https://github.com/microsoft/PowerPlatformConnectors).
+
+### Customizing Connector Metadata
+
+Edit `connector-config.yaml` at the repository root to customize:
+
+- Publisher name and support contact
+- Branding (icon color)
+- Authentication configuration
+- README documentation sections
+- Prerequisites and limitations
+
+**Example:**
+
+```yaml
+publisher: Fulcrum
+iconBrandColor: "#EB1300"
+authentication:
+  type: apiKey
+  displayName: Fulcrum API Token
+prerequisites:
+  - Active Fulcrum subscription with API access enabled
+```
+
+After editing, run `./scripts/convert_openapi.sh` to regenerate the certification package.
+
+**Note:** Keep prerequisites and limitations concise. Avoid mentioning specific plan types or redundant setup instructions.
 
 ## For More Information
 

--- a/connector-config.yaml
+++ b/connector-config.yaml
@@ -1,0 +1,36 @@
+# Fulcrum Power Automate Connector Configuration
+# This file contains metadata used to generate Microsoft certification package files
+
+# Required fields
+publisher: Fulcrum
+displayName: Fulcrum
+description: |
+  Fulcrum is a mobile data collection platform for field teams.
+  This connector enables integration with Fulcrum's API for managing
+  field data, photos, videos, and more.
+iconBrandColor: "#EB1300"
+category: Field Productivity
+supportEmail: support@fulcrumapp.com
+supportUrl: https://www.fulcrumapp.com/support
+
+# Authentication configuration (for apiProperties.json)
+authentication:
+  type: apiKey
+  parameterName: x-apitoken
+  displayName: Fulcrum API Token
+  description: Your Fulcrum API token from the settings page
+  tooltip: Get your API token from https://web.fulcrumapp.com/settings/api
+
+# README.md sections
+prerequisites:
+  - Active Fulcrum subscription with API access enabled
+
+knownLimitations:
+  - Rate limiting applies based on your Fulcrum plan
+
+# Optional README sections
+gettingStarted: |
+  Create a new connection in Power Automate and enter your API token when prompted.
+
+# Documentation
+documentationUrl: https://developer.fulcrumapp.com

--- a/openspec/changes/archive/2026-01-12-add-certification-packaging/design.md
+++ b/openspec/changes/archive/2026-01-12-add-certification-packaging/design.md
@@ -1,0 +1,344 @@
+# Design: Microsoft Certification Packaging
+
+## Overview
+
+This design adds automated generation of Microsoft Power Platform certification artifacts as the final step in the conversion pipeline. The solution follows the existing pipeline pattern: configuration → transformation → validation.
+
+## Architecture
+
+### Components
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Conversion Pipeline                           │
+├─────────────────────────────────────────────────────────────────┤
+│  download → 3.1→3.0 → 3.0→2.0 → clean → augment → [PACKAGE]    │
+└─────────────────────────────────────────────────────────────────┘
+                                                        │
+                                                        ▼
+                                        ┌───────────────────────────┐
+                                        │ certification_packager.py │
+                                        └───────────────────────────┘
+                                                        │
+                        ┌───────────────────────────────┼───────────────────────────────┐
+                        ▼                               ▼                               ▼
+            ┌────────────────────────┐    ┌────────────────────────┐    ┌────────────────────────┐
+            │ apiDefinition.         │    │ apiProperties.json     │    │ README.md              │
+            │ swagger.json           │    │                        │    │                        │
+            │                        │    │ - connectionParameters │    │ - Prerequisites        │
+            │ (YAML → JSON)          │    │ - iconBrandColor       │    │ - Obtaining Credentials│
+            │                        │    │ - capabilities         │    │ - Supported Operations │
+            └────────────────────────┘    └────────────────────────┘    └────────────────────────┘
+```
+
+### Data Flow
+
+1. **Input**: `fulcrum-power-automate-connector.yaml` (from trigger augmenter)
+2. **Configuration**: `connector-config.yaml` (repository root)
+3. **Processing**: `certification_packager.py` reads both inputs
+4. **Output**: Three files in `build/certified-connectors/Fulcrum/`
+
+### Configuration Schema
+
+The `connector-config.yaml` file centralizes all connector metadata:
+
+```yaml
+# Required fields
+publisher: Fulcrum
+displayName: Fulcrum
+description: |
+  Fulcrum is a mobile data collection platform for field teams.
+  This connector enables integration with Fulcrum's API for managing
+  field data, photos, videos, and more.
+iconBrandColor: "#EB1300"
+category: Field Productivity
+supportEmail: support@fulcrumapp.com
+supportUrl: https://www.fulcrumapp.com/support
+
+# Authentication configuration (for apiProperties.json)
+authentication:
+  type: apiKey
+  parameterName: x-apitoken
+  displayName: Fulcrum API Token
+  description: Your Fulcrum API token from the settings page
+  tooltip: Get your API token from https://web.fulcrumapp.com/settings/api
+
+# README.md sections
+prerequisites:
+  - Active Fulcrum subscription with API access enabled
+
+knownLimitations:
+  - Rate limiting applies based on your Fulcrum plan
+
+# Optional README sections
+gettingStarted: |
+  Create a new connection in Power Automate and enter your API token when prompted.
+
+faqs:
+  - question: How do I get an API token?
+    answer: Log in to Fulcrum, navigate to Settings > API, and generate a new token.
+
+deploymentInstructions: |
+  To deploy this connector as a custom connector:
+  1. Download the apiDefinition.swagger.json file
+  2. In Power Automate, go to Data > Custom Connectors
+  3. Click "New custom connector" > "Import an OpenAPI file"
+  4. Select the downloaded file and follow the wizard
+
+# Documentation
+documentationUrl: https://developer.fulcrumapp.com
+```
+
+## Implementation Decisions
+
+### Why a Single Configuration File?
+
+**Decision**: Use `connector-config.yaml` rather than embedding values in templates or multiple config files.
+
+**Rationale**:
+- Single source of truth for all connector metadata
+- Easier to maintain and update (one file to edit)
+- Human-readable YAML format is easier to edit than JSON
+- Supports validation against a schema
+- Can be version-controlled with clear change history
+- Consistent with other YAML files in the project (swagger specs, Docker compose, etc.)
+
+**Alternatives considered**:
+- Template files with placeholders: More files to maintain, harder to validate
+- Hardcoded values in Python: Requires code changes for metadata updates
+- Multiple config files: Fragments single source of truth
+
+### Why Python for Packaging?
+
+**Decision**: Implement `certification_packager.py` in Python rather than Bash + jq.
+
+**Rationale**:
+- Consistent with existing tools (`swagger_cleaner.py`, `trigger_augmenter.py`)
+- PyYAML already installed and used in pipeline
+- Better JSON manipulation than Bash + jq for complex structures
+- Easier to generate formatted markdown
+- Can leverage Python's template string formatting
+- Better error handling and validation capabilities
+
+### Why Generate README vs Template?
+
+**Decision**: Generate README.md dynamically using Microsoft's certified connector template structure, populating sections from `connector-config.yaml` and extracting operations from the spec.
+
+**Template Source**: https://github.com/microsoft/PowerPlatformConnectors/blob/dev/templates/certified-connectors/readme.md
+
+**Rationale**:
+- Follows Microsoft's required structure for certified connectors
+- Operations list stays synchronized with spec automatically
+- Reduces manual maintenance when endpoints change
+- Ensures documentation accuracy and compliance with certification requirements
+- Can include operation counts, categorization, parameter details
+- Populates required sections (Prerequisites, Obtaining Credentials, etc.) from config
+
+**Template Structure** (with Fulcrum title):
+
+```markdown
+# Fulcrum
+{description from connector-config.yaml}
+
+## Publisher: {publisher from connector-config.yaml}
+Required. Company or organization name.
+
+## Prerequisites
+{prerequisites from connector-config.yaml - concise list without plan specifics}
+
+## Supported Operations
+{Generated from swagger spec operations - concise list}
+
+## Obtaining Credentials
+{Generated from authentication section - where to get credentials, not how to use them}
+
+## Getting Started
+{Optional - how to create connection and use credentials, not how to obtain them}
+
+## Known Issues and Limitations
+{knownLimitations from connector-config.yaml - concise list without plan specifics}
+
+## Frequently Asked Questions
+{Optional - can be added to connector-config.yaml as FAQ array}
+
+## Deployment Instructions
+{Standard instructions for deploying as custom connector}
+```
+
+**Configuration Mapping**:
+- Title: Hardcoded as "Fulcrum"
+- Description: `connector-config.yaml: description`
+- Publisher: `connector-config.yaml: publisher`
+- Prerequisites: `connector-config.yaml: prerequisites[]`
+- Supported Operations: Extracted from `paths` in swagger spec
+- Obtaining Credentials: Generated from `connector-config.yaml: authentication`
+- Known Issues: `connector-config.yaml: knownLimitations[]`
+- Deployment Instructions: Standard template text
+
+**Trade-off**: Generated READMEs follow strict template structure but ensure compliance with Microsoft certification requirements.
+
+### Output Directory Structure
+
+**Decision**: Use `build/certified-connectors/Fulcrum/` structure.
+
+**Rationale**:
+- Matches Microsoft PowerPlatformConnectors repository structure
+- Easy to submit: copy entire `Fulcrum/` directory to fork
+- Supports potential future multiple connector packaging
+- Clear namespace separation from other build artifacts
+- Consistent with Microsoft's conventions for certified connectors
+
+### File Format: JSON vs YAML for apiDefinition
+
+**Decision**: Convert YAML to JSON for `apiDefinition.swagger.json`.
+
+**Rationale**:
+- Microsoft's schema explicitly expects `.json` extension
+- Power Platform's import tool may not handle YAML
+- Examples in PowerPlatformConnectors repository use JSON
+- JSON is more universally supported in tooling
+- Conversion is straightforward: PyYAML can load YAML and output JSON
+
+## Validation Strategy
+
+### Pre-Generation Validation
+
+Before generating files, validate:
+- `connector-config.yaml` exists and is valid YAML
+- Required config fields are present
+- Input Swagger YAML file exists and is valid
+
+### Post-Generation Validation
+
+After generating files, validate:
+- All three files exist with correct names
+- `apiDefinition.swagger.json` is valid JSON
+- `apiProperties.json` contains required Microsoft fields
+- `README.md` contains required sections
+- File sizes are reasonable (not empty, not truncated)
+
+### Schema Validation (Future Enhancement)
+
+Could add JSON Schema validation against Microsoft's schemas:
+- `schemas/apiDefinition.swagger.schema.json`
+- `schemas/paconn-apiProperties.schema.json`
+
+## Error Handling
+
+### Configuration Errors
+
+If `connector-config.yaml` is missing or invalid:
+- Print clear error message with expected location
+- Provide example config structure
+- Exit with non-zero status code
+- Do not generate partial files
+
+### Conversion Errors
+
+If YAML → JSON conversion fails:
+- Report specific parsing error
+- Indicate which line/field caused failure
+- Preserve input file for debugging
+- Exit without creating output directory
+
+### README Generation Errors
+
+If operations cannot be parsed:
+- Generate README with placeholder operations section
+- Include warning comment in generated file
+- Log warning but continue (non-fatal)
+- Still produces usable apiDefinition and apiProperties files
+
+## Testing Approach
+
+### Manual Testing
+
+1. Run full pipeline with default Fulcrum config
+2. Verify generated files manually against Microsoft examples
+3. Test import into Power Platform (if access available)
+
+### Validation Testing
+
+1. Test with missing config file
+2. Test with invalid JSON in config
+3. Test with missing required config fields
+4. Test with malformed input YAML
+5. Verify validation script catches all error cases
+
+### Configuration Testing
+
+1. Modify each config field
+2. Verify changes appear in correct output files
+3. Test edge cases (empty arrays, special characters in strings)
+4. Test YAML-specific features (multi-line strings, comments)
+
+## Future Enhancements
+
+### Icon Support
+
+**Current**: No icon file handling (Phase 1)
+**Future**: Add icon file support
+- Accept `icon.png` path in config
+- Copy icon to certification output directory
+- Validate icon dimensions (32x32, 64x64, etc.)
+- Validate PNG format
+
+### Custom Code Support
+
+**Current**: No custom code/scripting
+**Future**: Add script.csx support for Power Platform policies
+- Configuration option for script file path
+- Include script.csx in output directory
+- Document policy template usage
+
+### Multi-Connector Support
+
+**Current**: Single connector (Fulcrum) hardcoded
+**Future**: Support multiple connectors from same pipeline
+- Array of connector configs
+- Generate separate directories per connector
+- Batch validation
+
+### Interactive Configuration
+
+**Current**: Manual YAML editing
+**Future**: CLI tool for config generation
+- Interactive prompts for required fields
+- Validation during input
+- Generate initial `connector-config.yaml`
+
+## Security Considerations
+
+### Sensitive Data
+
+**No secrets in config**: `connector-config.yaml` must not contain:
+- API keys or tokens
+- Client secrets
+- OAuth credentials
+- Private URLs
+
+**Client IDs OK**: OAuth client IDs can be in config (not secret)
+
+### Validation
+
+- Scan config file for suspicious patterns (secrets, tokens)
+- Warn if potentially sensitive data detected
+- Document security requirements in README
+
+## Dependencies
+
+### External
+
+- PyYAML: YAML parsing and JSON generation (already installed)
+- Python 3.9+: Required for type hints and modern features
+
+### Internal
+
+- `fulcrum-power-automate-connector.yaml`: Input from trigger augmenter
+- `connector-config.yaml`: User-provided configuration
+- `build/` directory: Existing output location
+
+### Optional
+
+- JSON Schema validators: For strict validation against Microsoft schemas
+- Icon processing libraries: For future icon support

--- a/openspec/changes/archive/2026-01-12-add-certification-packaging/proposal.md
+++ b/openspec/changes/archive/2026-01-12-add-certification-packaging/proposal.md
@@ -1,0 +1,40 @@
+# Change: Add Microsoft Certification Packaging
+
+## Why
+
+Microsoft Power Platform requires three specific files for certified connector submission:
+1. `apiDefinition.swagger.json` - The OpenAPI/Swagger specification
+2. `apiProperties.json` - Connector metadata, branding, and authentication configuration
+3. `README.md` - Documentation with prerequisites, setup instructions, and operations list
+
+Currently, the conversion pipeline outputs `fulcrum-power-automate-connector.yaml` but doesn't package it for Microsoft certification. Manual file creation is error-prone and time-consuming. Automating this packaging step ensures:
+- Consistent metadata across submissions
+- Reduced manual work when updating the connector
+- Validation that all required files meet Microsoft's schema requirements
+- Proper structure matching Microsoft's PowerPlatformConnectors repository format
+
+As a verified publisher submitting a certified connector, the submission must include properly formatted files with correct branding (Fulcrum brand color #EB1300), authentication configuration (API key), and comprehensive documentation.
+
+## What Changes
+
+- Add a new pipeline step (`certification_packager.py`) that generates Microsoft certification files from the cleaned Swagger spec
+- Create a configuration file (`connector-config.yaml`) to store reusable connector metadata (publisher, branding, authentication, support contact, README content)
+- Modify `convert_openapi.sh` to call the certification packager after trigger augmentation
+- Generate three output files in `build/certified-connectors/Fulcrum/`:
+  - `apiDefinition.swagger.json` (converted from YAML)
+  - `apiProperties.json` (generated from config + spec analysis)
+  - `README.md` (generated following Microsoft's template structure: https://github.com/microsoft/PowerPlatformConnectors/blob/dev/templates/certified-connectors/readme.md with "Fulcrum" as title)
+- Update `validate.sh` to verify certification package completeness, schema compliance, and README template conformance
+- Update `.gitignore` to exclude `build/certified-connectors/` directory
+
+## Impact
+
+- Affected specs: `conversion-pipeline`
+- Affected code:
+  - `scripts/convert_openapi.sh` - Add call to certification packager
+  - `scripts/certification_packager.py` - New file for generating certification artifacts
+  - `scripts/validate.sh` - Add validation for certification package
+  - `connector-config.yaml` - New configuration file (root directory)
+  - `.gitignore` - Add certification output directory
+- Output: The pipeline will produce a complete, submission-ready certification package in `build/certified-connectors/Fulcrum/` containing all three required files with proper branding, authentication configuration, and documentation
+- Users: Fulcrum developers submitting connector updates to Microsoft will have automated, validated certification packages ready for pull request submission to microsoft/PowerPlatformConnectors repository

--- a/openspec/changes/archive/2026-01-12-add-certification-packaging/specs/conversion-pipeline/spec.md
+++ b/openspec/changes/archive/2026-01-12-add-certification-packaging/specs/conversion-pipeline/spec.md
@@ -1,43 +1,6 @@
-# conversion-pipeline Specification
+# conversion-pipeline Specification Delta
 
-## Purpose
-TBD - created by archiving change add-powerautomate-triggers. Update Purpose after archive.
-## Requirements
-### Requirement: Webhook Payload Schema Definition
-
-The augmented spec SHALL include a schema definition for Fulcrum webhook payloads.
-
-#### Scenario: Payload schema structure
-- **WHEN** the augmented spec is generated
-- **THEN** it SHALL contain a `FulcrumWebhookPayload` definition
-- **AND** the definition SHALL include `id`, `type`, and `data` properties at minimum
-- **AND** each property SHALL have `x-ms-summary` for Power Automate UI
-- **AND** the `type` property description SHALL document all supported event types (record.*, form.*, choice_list.*, classification_set.*)
-- **AND** the `data` property description SHALL indicate support for multiple resource types
-
-#### Scenario: Payload schema referenced by trigger
-- **WHEN** the `x-ms-notification-content` is defined
-- **THEN** it SHALL reference the `FulcrumWebhookPayload` schema via `$ref`
-
-### Requirement: User Experience Extensions
-
-The augmented spec SHALL include extensions that improve the Power Automate user experience.
-
-#### Scenario: Trigger summary format
-- **WHEN** the webhook trigger is displayed in Power Automate
-- **THEN** the summary SHALL follow the pattern "When a [event description]"
-- **AND** the summary SHALL be sentence case
-
-#### Scenario: Operation descriptions
-- **WHEN** Power Automate displays trigger details
-- **THEN** the description SHALL explain what events trigger the flow
-- **AND** the description SHALL mention Fulcrum as the event source
-- **AND** the description SHALL list all supported resource types (records, forms, choice lists, classification sets)
-
-#### Scenario: Parameter summaries
-- **WHEN** the trigger configuration UI is displayed
-- **THEN** visible parameters SHALL have `x-ms-summary` with title case labels
-- **AND** parameters SHALL have descriptive `description` text
+## ADDED Requirements
 
 ### Requirement: Certification Package Generation
 
@@ -242,3 +205,26 @@ Generated certification artifacts SHALL be properly managed in the build system 
 - **AND** it SHALL overwrite existing files in the output directory
 - **AND** old/stale files SHALL be replaced with fresh generated files
 
+## ADDED Requirements (continued)
+
+### Requirement: Pipeline Output Documentation
+
+The conversion pipeline documentation SHALL include information about certification package output.
+
+#### Scenario: Updated pipeline completion message
+- **WHEN** the conversion pipeline completes successfully
+- **THEN** the completion message SHALL list `apiDefinition.swagger.json`, `apiProperties.json`, and `README.md`
+- **AND** the message SHALL indicate their location in `build/certified-connectors/Fulcrum/`
+- **AND** the message SHALL mention they are ready for Microsoft certification submission
+
+#### Scenario: AGENTS.md validation workflow updated
+- **WHEN** the AGENTS.md file documents the validation workflow
+- **THEN** it SHALL include certification package validation as a step
+- **AND** it SHALL document expected certification file locations
+- **AND** it SHALL list certification-specific validation checks
+
+#### Scenario: README.md usage instructions updated
+- **WHEN** the project README.md explains usage
+- **THEN** it SHALL document the certification package output
+- **AND** it SHALL explain the purpose of `connector-config.yaml`
+- **AND** it SHALL provide instructions for customizing connector metadata

--- a/openspec/changes/archive/2026-01-12-add-certification-packaging/tasks.md
+++ b/openspec/changes/archive/2026-01-12-add-certification-packaging/tasks.md
@@ -1,0 +1,113 @@
+# Implementation Tasks
+
+## Phase 1: Configuration and Core Packaging Script
+
+- [x] Create `connector-config.yaml` at repository root with Fulcrum-specific metadata
+  - Publisher: "Fulcrum"
+  - Display name: "Fulcrum"
+  - Description: Multi-line description for README title section
+  - Brand color: "#EB1300"
+  - Category: "Field Productivity"
+  - Support email: "support@fulcrumapp.com"
+  - Authentication type: "apiKey"
+  - API token field configuration (display name, description, tooltip)
+  - Prerequisites array (for README Prerequisites section)
+  - Known limitations array (for README Known Issues and Limitations section)
+  - Optional: Getting started text (for README Getting Started section)
+
+- [x] Create `scripts/certification_packager.py` with core functionality
+  - Parse `connector-config.yaml` for metadata
+  - Read input Swagger YAML spec (`fulcrum-power-automate-connector.yaml`)
+  - Create output directory structure: `build/certified-connectors/Fulcrum/`
+  - Implement YAML to JSON conversion for `apiDefinition.swagger.json`
+
+## Phase 2: API Properties Generation
+
+- [x] Implement `apiProperties.json` generation in `certification_packager.py`
+  - Generate `properties.connectionParameters` for API key authentication
+  - Set `iconBrandColor` from config
+  - Set `capabilities` array (empty for cloud-only)
+  - Include `policyTemplateInstances` array (empty if no policies needed)
+  - Validate against Microsoft's apiProperties.json schema structure
+
+## Phase 3: README Generation
+
+- [x] Implement `README.md` generation in `certification_packager.py`
+  - Follow Microsoft's certified connector template: https://github.com/microsoft/PowerPlatformConnectors/blob/dev/templates/certified-connectors/readme.md
+  - Use "Fulcrum" as the title (# Fulcrum)
+  - Include connector description from config's `description` field
+  - Add "Publisher: {publisher}" section (e.g., "Publisher: Fulcrum")
+  - Add "Prerequisites" section from config's `prerequisites` array
+  - Add "Supported Operations" section by parsing spec paths/operations
+  - Add "Obtaining Credentials" section from config's `authentication` settings
+  - Add "Getting Started" section from config's optional `gettingStarted` field
+  - Add "Known Issues and Limitations" section from config's `knownLimitations` array
+
+## Phase 4: Pipeline Integration
+
+- [x] Update `scripts/convert_openapi.sh` to call certification packager
+  - Add call to `certification_packager.py` after `trigger_augmenter.py`
+  - Pass appropriate file paths and error handling
+  - Update completion message to mention certification package location
+
+- [x] Update `.gitignore` to exclude certification output
+  - Add `build/certified-connectors/` to ignore list (already covered by `build/`)
+
+## Phase 5: Validation
+
+- [x] Update `scripts/validate.sh` to validate certification package
+  - Check that all three files exist in expected location
+  - Verify `apiDefinition.swagger.json` is valid JSON (not YAML)
+  - Verify `apiProperties.json` has required fields: `properties.connectionParameters`, `properties.iconBrandColor`
+  - Verify `README.md` has required sections per Microsoft template:
+    - Title: "# Fulcrum"
+    - "## Publisher: {name}"
+    - "## Prerequisites"
+    - "## Supported Operations"
+    - "## Obtaining Credentials"
+    - "## Known Issues and Limitations"
+  - Check file sizes are reasonable
+  - Report certification package validation results
+
+## Phase 6: Documentation
+
+- [x] Update `AGENTS.md` with certification packaging workflow
+  - Document new validation steps for certification package
+  - Add certification package to expected output files list
+  - Document `connector-config.yaml` purpose and structure
+
+- [x] Update `README.md` with certification packaging information
+  - Document the certification package output location
+  - Explain how to customize connector metadata via `connector-config.yaml`
+  - Add example of certification package structure
+
+## Phase 7: Testing
+
+- [x] Test complete pipeline with certification packaging
+  - Run full workflow: download → convert → clean → augment → package
+  - Verify all three certification files are generated correctly
+  - Validate JSON structure matches Microsoft's examples
+  - Verify README markdown formatting and completeness
+  - Confirm operations list matches spec endpoints
+  - Test validation script catches missing/invalid certification files
+
+- [x] Test configuration customization
+  - Modify `connector-config.yaml` values
+  - Verify changes propagate to generated files correctly
+
+## Dependencies and Parallelization
+
+**Sequential dependencies:**
+- Phase 1 must complete before Phase 2, 3
+- Phase 2, 3 can be implemented in parallel (both depend on Phase 1)
+- Phase 4 depends on Phase 1, 2, 3 completion
+- Phase 5 depends on Phase 4
+- Phase 6, 7 can start after Phase 4 completes
+
+**User-visible progress:**
+- After Phase 1: Configuration file exists
+- After Phase 2-3: Manual execution of packager produces certification files
+- After Phase 4: Automated pipeline produces certification package
+- After Phase 5: Validation confirms package quality
+- After Phase 6: Documentation updated
+- After Phase 7: Complete, tested feature

--- a/scripts/certification_packager.py
+++ b/scripts/certification_packager.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+Microsoft Power Platform Certification Packager
+
+Generates the three required files for Microsoft Power Platform connector certification:
+1. apiDefinition.swagger.json - The OpenAPI/Swagger specification in JSON format
+2. apiProperties.json - Connector metadata, branding, and authentication configuration
+3. README.md - Documentation with prerequisites, setup, and operations
+
+Usage:
+    python certification_packager.py <swagger_yaml_path> <config_yaml_path> <output_dir>
+"""
+
+import sys
+import os
+import json
+import yaml
+from typing import Dict, Any
+
+
+def load_yaml_file(file_path: str) -> Dict[str, Any]:
+    """Load and parse a YAML file."""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            return yaml.safe_load(f)
+    except FileNotFoundError:
+        print(f"ERROR: File not found: {file_path}", file=sys.stderr)
+        sys.exit(1)
+    except yaml.YAMLError as e:
+        print(f"ERROR: Invalid YAML in {file_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def validate_config(config: Dict[str, Any]) -> None:
+    """Validate that the configuration contains all required fields."""
+    required_fields = [
+        'publisher',
+        'displayName',
+        'description',
+        'iconBrandColor',
+        'supportEmail',
+        'authentication',
+        'prerequisites',
+        'knownLimitations'
+    ]
+    
+    missing_fields = [field for field in required_fields if field not in config or not config[field]]
+    
+    if missing_fields:
+        print(f"ERROR: Missing required fields in connector-config.yaml: {', '.join(missing_fields)}", file=sys.stderr)
+        sys.exit(1)
+    
+    # Validate authentication config
+    auth = config.get('authentication', {})
+    auth_required = ['type', 'displayName', 'description']
+    auth_missing = [field for field in auth_required if field not in auth or not auth[field]]
+    
+    if auth_missing:
+        print(f"ERROR: Missing required authentication fields: {', '.join(auth_missing)}", file=sys.stderr)
+        sys.exit(1)
+
+
+def generate_api_definition(swagger_spec: Dict[str, Any], output_path: str) -> None:
+    """
+    Generate apiDefinition.swagger.json by converting YAML to JSON.
+    
+    Args:
+        swagger_spec: The parsed Swagger specification
+        output_path: Path where the JSON file should be written
+    """
+    try:
+        with open(output_path, 'w', encoding='utf-8') as f:
+            json.dump(swagger_spec, f, indent=2)
+        print(f"✓ Generated: {output_path}")
+    except Exception as e:
+        print(f"ERROR: Failed to write apiDefinition.swagger.json: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def generate_api_properties(config: Dict[str, Any], output_path: str) -> None:
+    """
+    Generate apiProperties.json with connection parameters and metadata.
+    
+    Args:
+        config: The connector configuration
+        output_path: Path where the JSON file should be written
+    """
+    auth = config['authentication']
+    
+    # Build connection parameters based on authentication type
+    connection_parameters = {}
+    
+    if auth['type'] == 'apiKey':
+        param_name = auth.get('parameterName', 'api_key')
+        connection_parameters[param_name] = {
+            "type": "securestring",
+            "uiDefinition": {
+                "displayName": auth['displayName'],
+                "description": auth['description'],
+                "tooltip": auth.get('tooltip', auth['description']),
+                "constraints": {
+                    "required": "true"
+                }
+            }
+        }
+    
+    api_properties = {
+        "properties": {
+            "connectionParameters": connection_parameters,
+            "iconBrandColor": config['iconBrandColor'],
+            "capabilities": [],
+            "policyTemplateInstances": []
+        }
+    }
+    
+    try:
+        with open(output_path, 'w', encoding='utf-8') as f:
+            json.dump(api_properties, f, indent=2)
+        print(f"✓ Generated: {output_path}")
+    except Exception as e:
+        print(f"ERROR: Failed to write apiProperties.json: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def generate_readme(config: Dict[str, Any], swagger_spec: Dict[str, Any], output_path: str) -> None:
+    """
+    Generate README.md following Microsoft's certified connector template.
+    
+    Args:
+        config: The connector configuration
+        swagger_spec: The parsed Swagger specification
+        output_path: Path where the README.md file should be written
+    """
+    readme_lines = []
+    
+    # Title and description
+    readme_lines.append("# Fulcrum")
+    readme_lines.append("")
+    readme_lines.append(config['description'].strip())
+    readme_lines.append("")
+    
+    # Publisher
+    readme_lines.append("## Publisher")
+    readme_lines.append("")
+    readme_lines.append(config['publisher'])
+    readme_lines.append("")
+    
+    # Prerequisites
+    readme_lines.append("## Prerequisites")
+    readme_lines.append("")
+    for prereq in config['prerequisites']:
+        readme_lines.append(f"- {prereq}")
+    readme_lines.append("")
+    
+    # Obtaining Credentials
+    readme_lines.append("## Obtaining Credentials")
+    readme_lines.append("")
+    auth = config['authentication']
+    readme_lines.append(auth['description'])
+    readme_lines.append("")
+    if 'tooltip' in auth:
+        readme_lines.append(auth['tooltip'])
+        readme_lines.append("")
+    
+    # Getting Started (optional)
+    if 'gettingStarted' in config and config['gettingStarted']:
+        readme_lines.append("## Getting Started")
+        readme_lines.append("")
+        readme_lines.append(config['gettingStarted'].strip())
+        readme_lines.append("")
+    
+    # Known Issues and Limitations
+    readme_lines.append("## Known Issues and Limitations")
+    readme_lines.append("")
+    for limitation in config['knownLimitations']:
+        readme_lines.append(f"- {limitation}")
+    readme_lines.append("")
+    
+    # Write the file
+    try:
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write('\n'.join(readme_lines))
+        print(f"✓ Generated: {output_path}")
+    except Exception as e:
+        print(f"ERROR: Failed to write README.md: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    """Main entry point for the certification packager."""
+    if len(sys.argv) != 4:
+        print("Usage: python certification_packager.py <swagger_yaml_path> <config_yaml_path> <output_dir>")
+        print("\nExample:")
+        print("  python certification_packager.py build/fulcrum-power-automate-connector.yaml \\")
+        print("         connector-config.yaml build/certified-connectors/Fulcrum")
+        sys.exit(1)
+    
+    swagger_yaml_path = sys.argv[1]
+    config_yaml_path = sys.argv[2]
+    output_dir = sys.argv[3]
+    
+    # Load configuration
+    print(f"Loading configuration from {config_yaml_path}...")
+    config = load_yaml_file(config_yaml_path)
+    validate_config(config)
+    
+    # Load Swagger specification
+    print(f"Loading Swagger specification from {swagger_yaml_path}...")
+    swagger_spec = load_yaml_file(swagger_yaml_path)
+    
+    # Create output directory
+    os.makedirs(output_dir, exist_ok=True)
+    print(f"Output directory: {output_dir}")
+    print("")
+    
+    # Generate the three required files
+    print("Generating certification package files...")
+    
+    api_definition_path = os.path.join(output_dir, "apiDefinition.swagger.json")
+    generate_api_definition(swagger_spec, api_definition_path)
+    
+    api_properties_path = os.path.join(output_dir, "apiProperties.json")
+    generate_api_properties(config, api_properties_path)
+    
+    readme_path = os.path.join(output_dir, "README.md")
+    generate_readme(config, swagger_spec, readme_path)
+    
+    print("")
+    print("================================================")
+    print("✓ Certification package generated successfully!")
+    print("")
+    print(f"Location: {output_dir}")
+    print("  - apiDefinition.swagger.json")
+    print("  - apiProperties.json")
+    print("  - README.md")
+    print("================================================")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_openapi.sh
+++ b/scripts/convert_openapi.sh
@@ -50,8 +50,23 @@ fi
 
 popd >/dev/null
 
-echo "Conversion, cleaning, and trigger augmentation completed successfully!"
+# Run certification_packager.py to generate Microsoft certification artifacts
+CERT_OUTPUT_DIR="${WORK_DIR}/certified-connectors/Fulcrum"
+CONFIG_PATH="${REPO_ROOT}/connector-config.yaml"
+
+if ! python3 "${SCRIPT_DIR}/certification_packager.py" "${SWAGGER_CLEAN_PATH}" "${CONFIG_PATH}" "${CERT_OUTPUT_DIR}"; then
+    echo "Error: certification_packager.py execution failed!"
+    exit 1
+fi
+
+echo ""
+echo "Conversion, cleaning, trigger augmentation, and certification packaging completed successfully!"
 echo "Output files are in ${WORK_DIR}:"
 echo "  - ${API_30_PATH}"
 echo "  - ${SWAGGER_PATH}"
 echo "  - ${SWAGGER_CLEAN_PATH} (with Power Automate trigger extensions)"
+echo ""
+echo "Certification package in ${CERT_OUTPUT_DIR}:"
+echo "  - apiDefinition.swagger.json"
+echo "  - apiProperties.json"
+echo "  - README.md"


### PR DESCRIPTION
# Purpose
This adds a final step to the conversion pipeline which packages the output into something that can be submitted to Microsoft for certification.

# Testing
With copilot run the `/convert` prompt and validate the output contains the following three files and they look valid.

1. README.md
2. apiProperties.json
3. apiDefinition.swagger.json